### PR TITLE
Stackable#2

### DIFF
--- a/stackables.js
+++ b/stackables.js
@@ -343,7 +343,12 @@ function stackablePopoverDirective() {
 
       // ensure z-index is above parent dialog
       var parentDialog = content.parent().closest('dialog');
-      var zIndex = parentDialog.css('z-index');
+      // JQuery in WebKit browsers does not give back a z-index value if
+      // an element's position is not explicitly set. Retrieve it from
+      // the style instead.
+      // https://bugs.jquery.com/ticket/9667
+      //var zIndex = parentDialog.css('z-index');
+      var zIndex = parentDialog.prop('style')['zIndex']
       var zIndexInt = parseInt(zIndex, 10);
       if(zIndexInt.toString() !== zIndex) {
         zIndex = 0;

--- a/stackables.js
+++ b/stackables.js
@@ -348,7 +348,7 @@ function stackablePopoverDirective() {
       // the style instead.
       // https://bugs.jquery.com/ticket/9667
       //var zIndex = parentDialog.css('z-index');
-      var zIndex = parentDialog.prop('style')['zIndex']
+      var zIndex = parentDialog.prop('style')['zIndex'];
       var zIndexInt = parseInt(zIndex, 10);
       if(zIndexInt.toString() !== zIndex) {
         zIndex = 0;
@@ -525,7 +525,7 @@ function stackableTriggerDirective($parse) {
     }
 
     function updateState(state) {
-      // If we're using the dialog polyfil, .offset() will calculate the
+      // If we're using the dialog polyfill, .offset() will calculate the
       // correct trigger position for us. If we aren't, .offset() needs
       // to be subtracted from the document's scroll position. This
       // fixes an issue we have with chrome, which doesn't use the polyfill.

--- a/stackables.js
+++ b/stackables.js
@@ -520,9 +520,17 @@ function stackableTriggerDirective($parse) {
     }
 
     function updateState(state) {
+      // If we're using the dialog polyfil, .offset() will calculate the
+      // correct trigger position for us. If we aren't, .offset() needs
+      // to be subtracted from the document's scroll position. This
+      // fixes an issue we have with chrome, which doesn't use the polyfill.
       var offset = element.offset();
+      var scrollOffset = 0;
+      if(!usePolyfill) {
+        scrollOffset = angular.element(document).scrollTop();
+      }
       state.position = {
-        top: offset.top,
+        top: offset.top - scrollOffset,
         left: offset.left,
         height: element.outerHeight(false),
         width: element.outerWidth(false),


### PR DESCRIPTION
Fixes https://github.com/digitalbazaar/angular-stackables/issues/2

Also fixes a bug with z-indexes in Safari. JQuery, when getting a z-index from the computed stylesheet (i.e. doing `element.css('z-index')`) will ignore any z-index that has been set if an element's positioning has also not been set https://bugs.jquery.com/ticket/9667. The two fixes for this would be to either explicitly set a positioning for all of our dialogs, or just get the z-index value from the stylesheet (I did the latter).
