### PR TITLE
Fix back button functionality in AngularJS 1.6+.

### DIFF
--- a/stackables.js
+++ b/stackables.js
@@ -66,6 +66,19 @@ var usePolyfill = angular.element('<dialog></dialog>');
 usePolyfill = (!usePolyfill[0].showModal &&
   typeof dialogPolyfill !== 'undefined');
 
+if(window.Element && !Element.prototype.closest) {
+  Element.prototype.closest = function(s) {
+    var matches = (this.document || this.ownerDocument).querySelectorAll(s),
+      i,
+      el = this;
+    do {
+      i = matches.length;
+      while (--i >= 0 && matches.item(i) !== el) {}
+    } while ((i < 0) && (el = el.parentElement));
+    return el;
+  };
+}
+
 /** HISTORY MANAGEMENT **/
 
 if(_hasHistoryAPI()) {
@@ -153,7 +166,7 @@ function stackableDirective() {
       var parent;
 
       // get z-index of parent dialog, if any
-      var parentDialog = element.parent().closest('dialog');
+      var parentDialog = angular.element(element.parent()[0].closest('dialog'));
       if(parentDialog.length === 0) {
         // no dialog parent; move dialog to body to simplify z-indexing
         parent = body;

--- a/stackables.js
+++ b/stackables.js
@@ -123,7 +123,7 @@ function _hasHistoryAPI() {
 function stackableDirective() {
   return {
     restrict: 'A',
-    controller: Controller
+    controller: ['$browser', Controller]
   };
 
   function Controller($browser) {

--- a/stackables.js
+++ b/stackables.js
@@ -85,7 +85,7 @@ if(_hasHistoryAPI()) {
   // user opens a modal, navigates to another site, and then presses the
   // `back` button... this will ensure to restore the original state as
   // if the modal was never opened on the page
-  var count = angular.element('body').data('stackables') || 0;
+  var count = angular.element(document.body).data('stackables') || 0;
   if(count === 0 && _hasHistoryAPI() && window.history.state &&
     window.history.state.stackables) {
     window.history.back();
@@ -148,7 +148,7 @@ function stackableDirective() {
       }
 
       self.isOpen = false;
-      var body = angular.element('body');
+      var body = angular.element(document.body);
       var dialog = element[0];
       var parent;
 


### PR DESCRIPTION
Changes to Angular 1.6, specifically:

https://github.com/angular/angular.js/commit/2b360bf30528e636da429396f2fe740c3f97c6f8

Resulted in angular detecting `window.history.pushState` changes.
As a result, the stackables state that is pushed when opening
a stackable was detected by angular on the next digest cycle,
resulting in angular issuing a route change event. This event
cannot be canceled using `preventDefault` as angular's `$browser`
will attempt to revert to the previous history when this happens,
thereby mangling the history. Detecting when to cancel the route
change may also be problematic as the necessary information to
determine whether it's a valid route change may not be available.

Instead, a horrible hack was written to override `onUrlChange`
listeners so that they will not detect any changes to history
state when a stackable is open or when all stackables have been
closed and we are reverting back to the previous history state.

This change also makes it such that links to the same route that
a stackable was opened from cannot be used in the stackable, but
this is generally considered an anti-pattern, defeating the
purpose of using a stackable to preserve the state on the route
it was launched from. So, don't use links like that.